### PR TITLE
add Sheetname as a configuration within the pipeline CR, web console …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SAMPLE_WATCH_DIRS=/churro
 GRPC_CERTS_DIR=certs/grpc
 DB_CERTS_DIR=certs/db
 BUILDDIR=./build
-PIPELINE=pipeline3
+PIPELINE=pipeline1
 CHURRO_NS=churro
 
 ## pick the database you want to use for the web console

--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -78,8 +78,8 @@ type ExtractSourceDefinition struct {
 	Tablename      string `json:"tablename"`
 	Cronexpression string `json:"cronexpression"`
 	Skipheaders    int    `json:"skipheaders"`
-	//Rule           []ExtractRule `json:"rule"`
-	//Ext            []Extension   `json:"ext"`
+	Multiline      string `json:"multiline"`
+	Sheetname      string `json:"sheetname"`
 }
 
 // PipelineSpec defines the desired state of Pipeline

--- a/deploy/operator/churro.project.io_pipelines.yaml
+++ b/deploy/operator/churro.project.io_pipelines.yaml
@@ -219,6 +219,10 @@ spec:
                       type: string
                     skipheaders:
                       type: integer
+                    sheetname:
+                      type: string
+                    multiline:
+                      type: string
                   required:
                   - id
                   - name

--- a/internal/ctl/extractsource.go
+++ b/internal/ctl/extractsource.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/rs/xid"
 	"github.com/rs/zerolog/log"
@@ -66,6 +67,10 @@ func (s *Server) CreateExtractSource(ctx context.Context, request *pb.CreateExtr
 		return nil, status.Errorf(codes.InvalidArgument,
 			"extract source skipheaders is required to be >= 0")
 	}
+	if wdir.Sheetname == "" && (wdir.Scheme == extractapi.XLSXScheme) {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"extract source sheetname is required for xlsx scheme")
+	}
 	if wdir.Tablename == "" {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"extract source tablename is required")
@@ -111,6 +116,8 @@ func (s *Server) CreateExtractSource(ctx context.Context, request *pb.CreateExtr
 		Tablename:      wdir.Tablename,
 		Cronexpression: wdir.Cronexpression,
 		Skipheaders:    wdir.Skipheaders,
+		Sheetname:      wdir.Sheetname,
+		Multiline:      strconv.FormatBool(wdir.Multiline),
 	}
 
 	pipelineToUpdate.Spec.Extractsources = append(pipelineToUpdate.Spec.Extractsources, esrc)

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -61,6 +61,8 @@ type ExtractSource struct {
 	Tablename      string `json:"tablename"`
 	Cronexpression string `json:"cronexpression"`
 	Skipheaders    int    `json:"skipheaders"`
+	Multiline      bool   `json:"multiline"`
+	Sheetname      string `json:"sheetname"`
 	// Initialized is calculated, not persisted
 	Initialized  bool                   `json:"initialized"`
 	Running      bool                   `json:"running"`

--- a/internal/extract/server.go
+++ b/internal/extract/server.go
@@ -118,6 +118,7 @@ func NewExtractServer(fileName, schemeValue, tableName string, debug bool, svcCr
 				Tablename:      c.Tablename,
 				Cronexpression: c.Cronexpression,
 				Skipheaders:    c.Skipheaders,
+				Sheetname:      c.Sheetname,
 				ExtractRules:   make(map[string]domain.ExtractRule),
 			}
 			g := pipelineToUpdate.Spec.Extractrules

--- a/internal/extract/xlsx.go
+++ b/internal/extract/xlsx.go
@@ -31,7 +31,7 @@ import (
 // ExtractXLS Excel file contents and exit
 func (s *Server) ExtractXLS(ctx context.Context) (err error) {
 
-	log.Info().Msg("ExtractXLS starting...")
+	log.Info().Msg("ExtractXLS starting...sheetname is " + s.ExtractSource.Sheetname)
 
 	xlsxFile, err := excelize.OpenFile(s.FileName)
 	if err != nil {
@@ -39,8 +39,8 @@ func (s *Server) ExtractXLS(ctx context.Context) (err error) {
 		return err
 	}
 
-	// TODO make sheetName configurable
-	sheetName := "Sheet1"
+	//sheetName := "Sheet1"
+	//sheetName := s.ExtractSource.Sheetname
 
 	dp := domain.DataProvenance{
 		Name: s.FileName,
@@ -54,9 +54,9 @@ func (s *Server) ExtractXLS(ctx context.Context) (err error) {
 	log.Info().Msg("dp info name " + dp.Name + " path " + dp.Path)
 
 	var rows [][]string
-	rows, err = xlsxFile.GetRows(sheetName)
+	rows, err = xlsxFile.GetRows(s.ExtractSource.Sheetname)
 	if err != nil {
-		log.Error().Stack().Err(err).Msg("could not GetRows xlsx file sheet " + sheetName)
+		log.Error().Stack().Err(err).Msg("could not GetRows xlsx file sheet " + s.ExtractSource.Sheetname)
 		return err
 	}
 

--- a/internal/extract/xlsx_test.go
+++ b/internal/extract/xlsx_test.go
@@ -37,6 +37,7 @@ func TestExtractXLSX(t *testing.T) {
 		ExtractRules: extractRules,
 		Tablename:    "myxlsxtable",
 		Skipheaders:  1,
+		Sheetname:    "Sheet1",
 	}
 
 	s := Server{

--- a/internal/handlers/extractsource.go
+++ b/internal/handlers/extractsource.go
@@ -214,6 +214,17 @@ func (u *HandlerWrapper) CreateExtractSource(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	rawValue := r.Form["multiline"][0]
+	if rawValue == "" {
+		rawValue = "false"
+	}
+	mV, err := strconv.ParseBool(rawValue)
+	if err != nil {
+		a := u.Copy("multiline is blank or not a valid boolean")
+		a.ShowCreateExtractSource(w, r)
+		return
+	}
+
 	d := domain.ExtractSource{
 		ID:             xid.New().String(),
 		Name:           r.Form["extractsourcename"][0],
@@ -222,6 +233,8 @@ func (u *HandlerWrapper) CreateExtractSource(w http.ResponseWriter, r *http.Requ
 		Regex:          r.Form["extractsourceregex"][0],
 		Tablename:      r.Form["extractsourcetablename"][0],
 		Cronexpression: r.Form["cronexpression"][0],
+		Multiline:      mV,
+		Sheetname:      r.Form["sheetname"][0],
 		Skipheaders:    v,
 		LastUpdated:    time.Now(),
 		ExtractRules:   make(map[string]domain.ExtractRule),
@@ -255,6 +268,11 @@ func (u *HandlerWrapper) CreateExtractSource(w http.ResponseWriter, r *http.Requ
 	}
 	if d.Skipheaders < 0 && (d.Scheme == extractapi.CSVScheme || d.Scheme == extractapi.XLSXScheme) {
 		a := u.Copy("skipheaders is required to be >= 0")
+		a.ShowCreateExtractSource(w, r)
+		return
+	}
+	if d.Sheetname == "" && (d.Scheme == extractapi.XLSXScheme) {
+		a := u.Copy("sheetname is required to be non-blank")
 		a.ShowCreateExtractSource(w, r)
 		return
 	}

--- a/pages/extractsource-create.html
+++ b/pages/extractsource-create.html
@@ -7,7 +7,16 @@
             .wfiedls{
                 dipslay: none;
             }
+            .wfiedls0{
+                dipslay: none;
+            }
             .wfiedls2{
+                dipslay: none;
+            }
+            .wfiedls3{
+                dipslay: none;
+            }
+            .wfiedls4{
                 dipslay: none;
             }
         </style>
@@ -26,25 +35,51 @@
                 var wcron = document.getElementById("cronexpression");
                 var wcronlabel = document.getElementById("cronexpressionlabel");
                 wregex.value = "[a-z,0-9].(" + scheme1.value + ")$";
-                if (scheme1.value == "api") {
-                  wpath.value = "https://someurl";
-                  wregex.value = "";
-                  //wcrondiv.style.display = "inline";
-                  $(".wfiedls").show();
-                } else {
-                  //wcrondiv.style.display = "none";
-                  $(".wfiedls").hide();
-                }
-
-                if (scheme1.value == "csv") {
-                  //wskipdiv.style.display = "inline";
-                  $(".wfiedls2").show();
-                } else if (scheme1.value == "xlsx") {
-                  //wskipdiv.style.display = "inline";
-                  $(".wfiedls2").show();
-                } else {
-                  //wskipdiv.style.display = "none";
-                  $(".wfiedls2").hide();
+                switch(scheme1.value) {
+                  case "api":
+                    wpath.value = "https://someurl";
+                    wregex.value = "";
+                    $(".wfiedls").show();
+                    $(".wfiedls0").hide();
+                    $(".wfiedls2").hide();
+                    $(".wfiedls3").hide();
+                    $(".wfiedls4").hide();
+                    break;
+                  case "csv":
+                    $(".wfiedls").hide();
+                    $(".wfiedls0").show();
+                    $(".wfiedls2").show();
+                    $(".wfiedls3").hide();
+                    $(".wfiedls4").hide();
+                    break;
+                  case "xlsx":
+                    $(".wfiedls").hide();
+                    $(".wfiedls0").show();
+                    $(".wfiedls2").show();
+                    $(".wfiedls3").hide();
+                    $(".wfiedls4").show();
+                    break;
+                  case "json":
+                    $(".wfiedls").hide();
+                    $(".wfiedls0").show();
+                    $(".wfiedls2").hide();
+                    $(".wfiedls3").show();
+                    $(".wfiedls4").hide();
+                    break;
+                  case "jsonpath":
+                    $(".wfiedls").hide();
+                    $(".wfiedls0").show();
+                    $(".wfiedls2").hide();
+                    $(".wfiedls3").show();
+                    $(".wfiedls4").hide();
+                    break;
+                  case "xml":
+                    $(".wfiedls").hide();
+                    $(".wfiedls0").show();
+                    $(".wfiedls2").hide();
+                    $(".wfiedls3").show();
+                    $(".wfiedls4").hide();
+                    break;
                 }
                 var wtname = document.getElementById("extractsourcetablename");
                 wtname.value = "my" + scheme1.value + "table";
@@ -87,7 +122,7 @@
                     <input type="text" class="form-control" id="extractsourcepath" name="extractsourcepath" value="/churro/csvfiles" data-toggle="tooltip" title="the file system path to be watched">
                 </div>
             </div>
-            <div class="form-group row">
+            <div class="form-group row wfiedls0">
                 <label for="extractsourceregex" class="col-sm-2 col-form-label">Regex</label>
                 <div class="col-sm-4">
                     <input type="text" class="form-control" id="extractsourceregex" name="extractsourceregex" value="[a-z,0-9].(csv)$" data-toggle="tooltip" title="a regex pattern for this extract source file type">
@@ -102,13 +137,29 @@
             <div class="form-group row wfiedls" id="crondiv" >
                 <label id="cronexpressionlabel" for="cronexpression" class="col-sm-2 col-form-label">Poll cron Expression</label>
                 <div class="col-sm-4">
-                    <input type="text" class="form-control" id="cronexpression" name="cronexpression" value="30s" data-toggle="tooltip" title="polling cronexpression">
+                    <input type="text" class="form-control" id="cronexpression" name="cronexpression" value="@every 1h" data-toggle="tooltip" title="polling cronexpression">
                 </div>
             </div>
             <div class="form-group row wfiedls2" id="skipheadersdiv">
                 <label id="skipheaderslabel" for="skipheaders" class="col-sm-2 col-form-label">Skip Headers</label>
                 <div class="col-sm-4">
                     <input type="number" min="0" max="10" class="form-control" id="skipheaders" name="skipheaders" value="0" data-toggle="tooltip" title="skip headers">
+                </div>
+            </div>
+            <div class="form-group row wfiedls3" id="multilinediv">
+                <label id="multilinelabel" for="multiline" class="col-sm-2 col-form-label">Multi-line</label>
+                <div class="col-sm-1">
+                    <input type="checkbox" class="form-control" id="multiline" name="multiline" value="true" data-toggle="tooltip" title="multiline content">
+                    <select class="form-control" id="multiline" name="multiline" data-toggle="tooltip" title="multi-line content">
+                        <option selected>false</option>
+                        <option>true</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group row wfiedls4" id="sheetnamediv">
+                <label id="sheetnamelabel" for="sheetname" class="col-sm-2 col-form-label">Excel Sheet Name</label>
+                <div class="col-sm-4">
+                    <input type="text" class="form-control" id="sheetname" name="sheetname" value="Sheet1" data-toggle="tooltip" title="spreadsheet sheet name">
                 </div>
             </div>
             <input type="hidden" id="pipelineid" name="pipelineid" value="{{.PipelineID}}">


### PR DESCRIPTION
this PR adds a 'sheetname' field to the pipeline CR, it updates the UI to allow users an ability to specify the xlxs sheet name, if nothing is specified, then 'Sheet1' is the default.  When an xlsx extractsource is created, the sheetname is carried forward for rthat extract processing.